### PR TITLE
HttpService -> XMLHttpService renaming

### DIFF
--- a/5.dip.py
+++ b/5.dip.py
@@ -26,7 +26,7 @@ class Http:
         self.xml_http_service.request(url, 'POST')
 
 """
-Here, Http is the high-level component whereas HttpService is the low-level
+Here, Http is the high-level component whereas XMLHttpService is the low-level
 component.  This design violates DIP A: High-level modules should not depend on
 low-level level modules. It should depend upon its abstraction.
 


### PR DESCRIPTION
There is no `HttpService` term/object in the code, however `HttpService` is mentioned in the text/docstring. This might lead to misunderstanding.  So, we need to rename `HttpService ` to `XMLHttpService`.